### PR TITLE
Add lint and build checks for pull requests onto main

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,2 @@
+# These are the default owners for the whole repo. They will be requested for review wehen someone opens a pull request.
+* @mezotv @Podskio

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -1,0 +1,26 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2        
+      - name: install dependencies
+        run: npm ci
+      - name: run lint
+        run:  npm run lint
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2        
+      - name: install dependencies
+        run: npm ci
+      - name: run build
+        run:  npm run build

--- a/.github/workflows/pr-lint-and-build.yml
+++ b/.github/workflows/pr-lint-and-build.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: Lint and Build
 
 on:
   pull_request:


### PR DESCRIPTION
This pr adds a github action to check lint and build for a pr onto the main branch.

@mezotv you can set a branch protection rule which needs these checks to succeed before merging.