### PR TITLE
feat: added pagination component and functionality

### DIFF
--- a/app/packs/_components/PacksPagination.tsx
+++ b/app/packs/_components/PacksPagination.tsx
@@ -1,0 +1,135 @@
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink
+} from '@/components/ui/pagination'
+import { useRouter, usePathname, useSearchParams } from 'next/navigation'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+function PacksPagination({ totalPages }: { totalPages: number }) {
+  const searchParams = useSearchParams()
+  const pathname = usePathname()
+  const router = useRouter()
+  const POSTS_PER_PAGE = 15
+  const SIBLING_PAGES = 1
+  const currentPage =
+    searchParams.get('page') ? parseInt(searchParams.get('page') as string) : 1
+
+  const hasPreviousPage = currentPage > 1
+  const hasNextPage = currentPage <= totalPages - 1
+
+  const createQueryString = (pageNum: number) => {
+    const params = new URLSearchParams(searchParams.toString())
+
+    if (pageNum === null || pageNum === 1) {
+      params.delete('page')
+    } else {
+      params.set('page', pageNum.toString())
+    }
+
+    return params ? '?' + params.toString() : pathname
+  }
+
+  const handlePageChange = (pageNum: number) => {
+    const query = createQueryString(pageNum)
+    router.push(query)
+  }
+
+  const generatePageNumbers = () => {
+    const pageNumbers = []
+
+    if (totalPages <= 5) {
+      // show all page numbers
+      for (let i = 1; i <= totalPages; i++) pageNumbers.push(i)
+    } else {
+      const leftSiblingIndex = Math.max(2, currentPage - 1)
+      const rightSiblingIndex = Math.min(totalPages - 1, currentPage + 1)
+      
+      // Ellipsis after first page
+      if (currentPage > 3) pageNumbers.push(null) 
+
+      // Show a range of pages around the current page
+      for (let i = leftSiblingIndex; i <= rightSiblingIndex; i++) {
+        if (i > 1 && i < totalPages) {
+          pageNumbers.push(i)
+        }
+      }
+      // Ellipsis before last page
+      if (currentPage < totalPages - 2) pageNumbers.push(null) 
+    }
+
+    return pageNumbers
+  }
+
+  return (
+    <Pagination>
+      <PaginationContent className='max-md:justify-between max-md:w-full'>
+        <PaginationItem>
+          <Button
+            className="gap-1"
+            variant="ghost"
+            disabled={!hasPreviousPage}
+            onClick={() => handlePageChange(currentPage - 1)}
+            aria-label="Go to previous page"
+          >
+            <ChevronLeft className="size-4" />
+            <span>Previous</span>
+          </Button>
+        </PaginationItem>
+
+        <PaginationItem  className="hidden md:block">
+          <PaginationLink
+            href={createQueryString(1)}
+            isActive={currentPage === 1}
+          >
+            1
+          </PaginationLink>
+        </PaginationItem>
+
+        {/* Page Numbers and Ellipses */}
+        {generatePageNumbers().map((pageNumber, index) => (
+          <PaginationItem
+            className="hidden md:block"
+            key={index}
+          >
+            {pageNumber ?
+              <PaginationLink
+                href={createQueryString(pageNumber)}
+                isActive={pageNumber === currentPage}
+              >
+                {pageNumber}
+              </PaginationLink>
+            : <PaginationEllipsis />}
+          </PaginationItem>
+        ))}
+
+        <PaginationItem className="hidden md:block">
+          <PaginationLink
+            href={createQueryString(totalPages)}
+            isActive={currentPage === totalPages}
+          >
+            {totalPages}
+          </PaginationLink>
+        </PaginationItem>
+
+        <PaginationItem>
+          <Button
+            className="gap-1"
+            variant="ghost"
+            disabled={!hasNextPage}
+            onClick={() => handlePageChange(currentPage + 1)}
+            aria-label="Go to next page"
+          >
+            <span>Next</span>
+            <ChevronRight className="size-4" />
+          </Button>
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  )
+}
+
+export default PacksPagination

--- a/app/packs/_components/PageContent.tsx
+++ b/app/packs/_components/PageContent.tsx
@@ -4,26 +4,12 @@ import { questionPacks } from '@/lib/constants'
 import QuestionPack from './QuestionPack'
 import Filter from './Filter'
 import React from 'react'
+import PacksPagination from './PacksPagination'
 
 function PageContent() {
+  // we'll get rid of all these when data is passed from server comp and just map over that  
   const searchParams = useSearchParams()
   const type = searchParams.get('type')
-  const page = parseInt(searchParams.get('page') || '1')
-
-  const getQuestionPacks = async () => {
-    const res = await fetch(`/api/packs?page=${page}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-    })
-    return await res.json()
-  }
-
-  const questionPack2s = getQuestionPacks()
-
-  console.log(questionPack2s)
-
   const packsToShow =
     type ? questionPacks.filter((pack) => pack.slug === type) : questionPacks
   
@@ -40,6 +26,7 @@ function PageContent() {
           ))}
         </ul>
       </section>
+      <PacksPagination totalPages={120} />
     </div>
   )
 }

--- a/app/packs/_components/QuestionPackDetails.tsx
+++ b/app/packs/_components/QuestionPackDetails.tsx
@@ -1,21 +1,19 @@
 import { CopyIcon, ExternalLink, Search } from 'lucide-react'
 
+import { Button } from '@/components/ui/button'
 import {
   Dialog,
-  DialogClose,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger
 } from '@/components/ui/dialog'
-import { QuestionPackProps } from './QuestionPack'
-import { toast } from '@/components/ui/use-toast'
-import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { toast } from '@/components/ui/use-toast'
 import { cn } from '@/lib/utils'
 import Image from 'next/image'
+import { QuestionPackProps } from './QuestionPack'
 
 export function QuestionPackDetails({
   id,
@@ -48,7 +46,7 @@ export function QuestionPackDetails({
           <span>Use pack</span>
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-w-[90%] sm:max-w-lg">
+      <DialogContent className="max-w-[90%] sm:max-w-lg lg:max-w-2xl">
         <DialogHeader>
           <DialogTitle>{name}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>

--- a/app/packs/page.tsx
+++ b/app/packs/page.tsx
@@ -4,44 +4,61 @@ import PageContent from './_components/PageContent'
 import { Metadata, Viewport } from 'next'
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://wouldyoubot.gg"),
+  metadataBase: new URL('https://wouldyoubot.gg'),
   alternates: {
-    canonical: "/",
+    canonical: '/'
   },
   title: 'Question Packs - Would You',
-  description: 'Explore a huge list of custom questions including would you rather, truth or dare, never have I ever, and many more!',
+  description:
+    'Explore a huge list of custom questions including would you rather, truth or dare, never have I ever, and many more!',
   twitter: {
-    title: "Question Packs - Would You",
-    card: "summary_large_image",
-    images: "/question-packs.png",
+    title: 'Question Packs - Would You',
+    card: 'summary_large_image',
+    images: '/question-packs.png',
     description:
-      "Explore a huge list of custom questions including would you rather, truth or dare, never have I ever, and many more!",
+      'Explore a huge list of custom questions including would you rather, truth or dare, never have I ever, and many more!'
   },
   openGraph: {
-    title: "Question Packs - Would You",
-    images: "/question-packs.png",
+    title: 'Question Packs - Would You',
+    images: '/question-packs.png',
     description:
-      "Explore a huge list of custom questions including would you rather, truth or dare, never have I ever, and many more!",
+      'Explore a huge list of custom questions including would you rather, truth or dare, never have I ever, and many more!'
   },
   robots: {
     index: true,
-    follow: true,
-  },
+    follow: true
+  }
 }
 
 export const viewport: Viewport = {
-	maximumScale: 5,
-	themeColor: "#0598F6",
-};
+  maximumScale: 5,
+  themeColor: '#0598F6'
+}
 
 export const dynamic = 'force-dynamic'
 
-const getPacks = async () => {
-  try {
-    const response = await fetch('/')
-  } catch (error) {
-    console.error(error)
+export interface PackResponse {
+  data: {
+    id: string
+    name: string
+    description: string
+    tags: string[]
+    likes: string[]
+    questions: string[]
+    featured: boolean
   }
+  pages: number
+}
+
+const getQuestionPacks = async (page: string, type: string) => {
+  const res = await fetch(`https://localhost:3000/api/packs?page=${page}&type=${type}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+  const resData: PackResponse = await res.json()
+  return resData
 }
 
 async function page({
@@ -49,14 +66,20 @@ async function page({
 }: {
   searchParams: { [key: string]: string | string[] | undefined }
 }) {
-  const type = searchParams.t
+  const type = searchParams.type ? searchParams.type as string : 'all'
+  const page = searchParams.page ? searchParams.page as string : '1';
+
+  // const data = await getQuestionPacks(page, type)
 
   return (
     <Container className="pt-8 lg:pt-10 space-y-8 min-h-[calc(100vh-112px)]">
-        <h1 className="text-4xl font-bold">
-          <span className="text-brand-red-100 drop-shadow-red-glow">Question</span>{" "}
+      <h1 className="text-4xl font-bold">
+        <span className="text-brand-red-100 drop-shadow-red-glow">
+          Question
+        </span>{' '}
         <span className="text-brand-blue-100 drop-shadow-blue-glow">Packs</span>
       </h1>
+      {/* pass data down */}
       <PageContent />
     </Container>
   )

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -1,0 +1,119 @@
+import * as React from "react"
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { ButtonProps, buttonVariants } from "@/components/ui/button"
+import Link from "next/link"
+
+const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
+  <nav
+    role="navigation"
+    aria-label="pagination"
+    className={cn("mx-auto flex w-full justify-center", className)}
+    {...props}
+  />
+)
+Pagination.displayName = "Pagination"
+
+const PaginationContent = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<"ul">
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    className={cn("flex flex-row items-center gap-1", className)}
+    {...props}
+  />
+))
+PaginationContent.displayName = "PaginationContent"
+
+const PaginationItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<"li">
+>(({ className, ...props }, ref) => (
+  <li ref={ref} className={cn("", className)} {...props} />
+))
+PaginationItem.displayName = "PaginationItem"
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<ButtonProps, "size"> &
+  React.ComponentProps<typeof Link>
+
+const PaginationLink = ({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) => (
+  <Link
+    aria-current={isActive ? "page" : undefined}
+    className={cn(
+      buttonVariants({
+        variant: isActive ? "outline" : "ghost",
+        size,
+      }),
+      className,
+      isActive && "bg-brand-blue-100 hover:bg-brand-blue-200 text-white hover:text-white"
+    )}
+    {...props}
+  />
+)
+PaginationLink.displayName = "PaginationLink"
+
+const PaginationPrevious = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to previous page"
+    size="default"
+    className={cn("gap-1 pl-2.5", className)}
+    {...props}
+  >
+    <ChevronLeft className="h-4 w-4" />
+    <span>Previous</span>
+  </PaginationLink>
+)
+PaginationPrevious.displayName = "PaginationPrevious"
+
+const PaginationNext = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to next page"
+    size="default"
+    className={cn("gap-1 pr-2.5", className)}
+    {...props}
+  >
+    <span>Next</span>
+    <ChevronRight className="h-4 w-4" />
+  </PaginationLink>
+)
+PaginationNext.displayName = "PaginationNext"
+
+const PaginationEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    aria-hidden
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More pages</span>
+  </span>
+)
+PaginationEllipsis.displayName = "PaginationEllipsis"
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+}


### PR DESCRIPTION
- Created the pagination component and logic to display a number of links at a time
- On mobile only the previous and next buttons are shown 
- Data is fetched server side and passed down
- Component takes only one prop: the total number of pages for the results (including type filter)

![Screenshot 2024-11-04 131900](https://github.com/user-attachments/assets/99c2d4c3-aad6-48da-86cc-771951cffad4)
